### PR TITLE
Print IMAP session buffer as a string literal

### DIFF
--- a/src/clientbase.c
+++ b/src/clientbase.c
@@ -281,7 +281,6 @@ int ci_write(ClientBase_T *client, char * msg, ...)
 	int e = 0;
 	uint64_t n, left;
 	char *s;
-	char buf[40];
 	int state;
 
 	if (! (client && client->write_buffer))
@@ -342,10 +341,7 @@ int ci_write(ClientBase_T *client, char * msg, ...)
 			} 
 		} 
 
-		memset(buf, 0, sizeof(buf));
-		strncpy(buf, s, sizeof(buf)-1);
-
-		TRACE(TRACE_DEBUG, "[%p] S > [%" PRId64 "/%" PRIu64 ":%s]", client, t, left, buf);
+		TRACE(TRACE_DEBUG, "[%p] S > [%" PRId64 "/%" PRIu64 ":%s]", client, t, left, s);
 
 		client->bytes_tx += t;	// Update our byte counter
 		client->write_buffer_offset += t;

--- a/src/imap4.c
+++ b/src/imap4.c
@@ -393,7 +393,7 @@ static void imap_handle_continue(ImapSession *session)
 	if (session->state < CLIENTSTATE_LOGOUT) {
 		if (session->buff && p_string_len(session->buff) > 0) {
 			int e = 0;
-			if ((e = ci_write(session->ci, (char *)p_string_str(session->buff))) < 0) {
+			if ((e = ci_write(session->ci, "%s", (char *)p_string_str(session->buff))) < 0) {
 				int serr = errno;
 				TRACE(TRACE_DEBUG,"ci_write returned error [%s]", strerror(serr));
 				imap_handle_abort(session);


### PR DESCRIPTION
Fix ci_write message logging, print the whole message instead of the first
40 characters.
