### PR TITLE
Fixes for utf8 headers

### DIFF
--- a/src/dbmail-message.c
+++ b/src/dbmail-message.c
@@ -1639,7 +1639,7 @@ static void _header_cache(const char *header, const char *raw, gpointer user_dat
 	volatile gboolean isaddr = 0, isdate = 0, issubject = 0;
 	const char *charset = dbmail_message_get_charset(self);
 	char datefield[32];
-	char sortfield[CACHE_WIDTH];
+	char sortfield[CACHE_WIDTH*4];
 	char *value = NULL;
 	InternetAddressList *emaillist;
 	InternetAddress *ia;
@@ -1719,7 +1719,7 @@ static void _header_cache(const char *header, const char *raw, gpointer user_dat
 	if(issubject) {
 		char *s, *t = dm_base_subject(value);
 		s = dbmail_iconv_str_to_db(t, charset);
-		g_strlcpy(sortfield, s, CACHE_WIDTH-1);
+		g_utf8_strncpy(sortfield, s, CACHE_WIDTH-1);
 		g_free(s);
 		g_free(t);
 	}
@@ -1738,7 +1738,7 @@ static void _header_cache(const char *header, const char *raw, gpointer user_dat
 	}
 
 	if (sortfield[0] == '\0')
-		g_strlcpy(sortfield, value, CACHE_WIDTH-1);
+		g_utf8_strncpy(sortfield, value, CACHE_WIDTH-1);
 
 	/* Fetch header value id if exists, else insert, and return new id */
 	_header_value_get_id(value, sortfield, datefield, &headervalue_id);

--- a/src/dm_iconv.c
+++ b/src/dm_iconv.c
@@ -217,6 +217,8 @@ char * dbmail_iconv_decode_field(const char *in, const char *charset, gboolean i
 {
 	char *tmp_raw;
 	char *value;
+	char *bad_char;
+	char *cur_char;
 
 	if ((tmp_raw = dbmail_iconv_str_to_utf8((const char *)in, charset)) == NULL) {
 		TRACE(TRACE_WARNING, "unable to decode headervalue [%s] using charset [%s]", in, charset);
@@ -229,6 +231,12 @@ char * dbmail_iconv_decode_field(const char *in, const char *charset, gboolean i
 		value = dbmail_iconv_decode_text(tmp_raw);
 
 	g_free(tmp_raw);
+
+	cur_char = value;
+	while (!g_utf8_validate((const gchar *)cur_char,-1,(const char **)&bad_char)) {
+		*bad_char = '?';
+		cur_char = bad_char+1;
+	}
 
 	return value;
 }

--- a/test/check_dbmail.h
+++ b/test/check_dbmail.h
@@ -758,6 +758,24 @@ char *encoded_message_utf8_2 = "X-Mozilla-Status: 0001\n"
 	"тест\n"
 	"\n";
 
+char *utf8_long_header =
+"Subject: =?UTF-8?B?0J/RgNC40LzQtdGAINC00L7RgdGC0LDRgtC+0YfQvdC+INC00Ls=?=\n"
+" =?UTF-8?B?0LjQvdC90L7Qs9C+INGC0LXQutGB0YLQsCDQsiDQv9C+0LvQtQ==?= Subject\n"
+" =?UTF-8?B?0LIg0LzQvdC+0LPQvtCx0LDQudGC0L7QstGL0YUg0YHQuNC80LLQvtC70LA=?=\n"
+" =?UTF-8?B?0YUgKNC90LDQv9GA0LjQvNC10YAsINC90LDQv9C40YHQsNC90L3Ri9GFINC9?=\n"
+" =?UTF-8?B?0LAg0YDRg9GB0YHQutC+0Lwg0Y/Qt9GL0LrQtSkg0L/RgNC40LLQvtC00Lg=?=\n"
+" =?UTF-8?B?0YIg0Log0YLQvtC80YMsINGH0YLQvg==?= sortfield =?UTF-8?B?0YTQvtGA?=\n"
+" =?UTF-8?B?0LzQuNGA0YPQtdGC0YHRjyDQsdC10Lcg0YPRh9GR0YLQsCDQvNC90L7Qs9C+?=\n"
+" =?UTF-8?B?0LHQsNC50YLQvtCy0YvRhSDRgdC40LzQstC+0LvQvtCyLCDRh9GC0L4g0LIg?=\n"
+" =?UTF-8?B?0YHQstC+0Y4g0L7Rh9C10YDQtdC00Ywg0L/RgNC40LLQvtC00LjRgiDQuiA=?=\n"
+" =?UTF-8?B?0YLQvtC80YMsINGH0YLQviDQsiDRgdGC0YDQvtC60LUg0L/RgNC40YHRg9GC?=\n"
+" =?UTF-8?B?0YHRgtCy0YPQtdGCINGC0L7Qu9GM0LrQviDQvdCw0YfQsNC70L4g0YHQuNC8?=\n"
+" =?UTF-8?B?0LLQvtC70LAuINCa0LDQuiwg0L3QsNC/0YDQuNC80LXRgCwg0LIg0Y3RgtC+?=\n"
+" =?UTF-8?B?0Lkg0YHRgtGA0L7QutC1Lg==?=";
+
+char *utf8_invalid =
+"Subject: =?UTF-8?B?0J/RgNC40LPQu9Cw0YjQsNC10Lwg0L3QsCDRgdC10YDQ?= =?UTF-8?B?INC60L7QvdC10YYg0YHRgtGA0L7QutC4?=";
+
 char *multipart_mixed = "Received: from RAIVO (raivo.kisise [192.168.111.49])\n"
 	"	by test.kisise (Postfix) with ESMTP id 5C4981214C\n"
 	"	for <test@test.kisise>; Thu,  5 Oct 2006 04:18:26 +0300 (EEST)\n"

--- a/test/check_dbmail_message.c
+++ b/test/check_dbmail_message.c
@@ -877,6 +877,80 @@ START_TEST(test_db_get_message_lines)
 }
 END_TEST
 
+/* Fetching subject from database */
+extern DBParam_T db_params;
+#define DBPFX db_params.pfx
+
+int test_db_get_subject(uint64_t physid, char **subject)
+{
+        Connection_T c; ResultSet_T r;
+        const char *query_result = NULL;
+        volatile int t = DM_EGENERAL;
+
+        c = db_con_get();
+        TRY
+                r = db_query(c, "SELECT subjectfield "
+                                "FROM %ssubjectfield WHERE physmessage_id = %" PRIu64 "",
+                                DBPFX,physid);
+                if (db_result_next(r)) {
+                        query_result = db_result_get(r, 0);
+                        if (query_result && (strlen(query_result) > 0)) {
+                                *subject = g_strdup(query_result);
+                        }
+                }
+                t = DM_SUCCESS;
+        CATCH(SQLException)
+                LOG_SQLERROR;
+        FINALLY
+                db_con_close(c);
+        END_TRY;
+
+        return t;
+}
+
+START_TEST(test_dbmail_message_utf8_headers)
+{
+	DbmailMessage *m;
+	uint64_t physid = 0;
+	char *s,*s_dec,*t = NULL;
+	char *utf8_invalid_fixed = "=?UTF-8?B?0J/RgNC40LPQu9Cw0YjQsNC10Lwg0L3QsCDRgdC10YA/IA==?= =?UTF-8?B?0LrQvtC90LXRhiDRgdGC0YDQvtC60Lg=?=";
+
+        m = dbmail_message_new(NULL);
+        m = dbmail_message_init_with_string(m,utf8_long_header);
+	dbmail_message_store(m);
+	physid = dbmail_message_get_physid(m);
+
+	s = dbmail_message_get_header(m,"Subject");
+	s_dec = g_mime_utils_header_decode_phrase(s);
+	test_db_get_subject(physid,&t);
+	//printf("Long [%s]\n[%s]\n",s_dec,t);
+
+        fail_unless(MATCH(s_dec,t), "utf8 long header failed");
+
+	g_free(s);
+	g_free(s_dec);
+	t = NULL;
+	physid = 0;
+
+
+	m = dbmail_message_new(NULL);
+	m = dbmail_message_init_with_string(m,utf8_invalid);
+	dbmail_message_store(m);
+	physid = dbmail_message_get_physid(m);
+
+	s = g_mime_utils_header_decode_phrase(utf8_invalid_fixed);
+	test_db_get_subject(physid,&t);
+	//printf("Invalid [%s]\n[%s]\n",s,t);
+
+        fail_unless(MATCH(s,t), "utf8 invalid failed");
+
+	g_free(s);
+	g_free(s_dec);
+	t = NULL;
+	physid = 0;
+}
+END_TEST
+
 Suite *dbmail_message_suite(void)
 {
 	Suite *s = suite_create("Dbmail Message");
@@ -908,6 +982,7 @@ Suite *dbmail_message_suite(void)
 	tcase_add_test(tc_message, test_dbmail_message_get_size);
 	tcase_add_test(tc_message, test_encoding);
 	tcase_add_test(tc_message, test_db_get_message_lines);
+	tcase_add_test(tc_message, test_dbmail_message_utf8_headers);
 	return s;
 }
 


### PR DESCRIPTION
Fixed long (>255) utf8 headers + unit-test
Added validation of invalid utf8 sequences (replacing invalid char with "?") + unit-test
