### PR TITLE
Disconnect IMAP clients if only few free FDs left

### DIFF
--- a/src/dbmail.h.in
+++ b/src/dbmail.h.in
@@ -69,12 +69,14 @@
 #include <string.h>
 #include <strings.h>
 #include <sysexits.h>
+#include <dirent.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <sys/mman.h>
 #include <sys/socket.h>
 #include <sys/un.h>
 #include <sys/time.h>
+#include <sys/resource.h>
 #include <sys/wait.h>
 #include <sys/ipc.h>
 #include <sys/shm.h>
@@ -251,6 +253,9 @@
 
 /* input reading linelimit */
 #define MAX_LINESIZE (64*1024)
+
+/* minumun number of free file descriptors required to run the daemon */
+#define FREE_DF_THRESHOLD 16
 
 /* string length for query */
 #define DEF_QUERYSIZE (32*1024)

--- a/src/dm_misc.c
+++ b/src/dm_misc.c
@@ -104,6 +104,26 @@ int drop_privileges(char *newuser, char *newgroup)
 	return 0;
 }
 
+int get_opened_fd_count(void)
+{
+	DIR* dir = NULL;
+	struct dirent* entry = NULL;
+	char buf[32];
+	int fd_count = 0;
+
+	snprintf(buf, 32, "/proc/%i/fd/", getpid());
+
+	dir = opendir(buf);
+	if (dir == NULL)
+		return -1;
+
+	while ((entry = readdir(dir)) != NULL)
+		fd_count++;
+	closedir(dir);
+
+	return fd_count - 2; /* exclude '.' and '..' entries */
+}
+
 void create_unique_id(char *target, uint64_t message_idnr)
 {
 	char md5_str[FIELDSIZE];

--- a/src/dm_misc.h
+++ b/src/dm_misc.h
@@ -45,6 +45,14 @@ void g_string_maybe_shrink(GString *s);
 int drop_privileges(char *newuser, char *newgroup);
 
 /**
+   \brief get the number of opened files (requires /proc mounted)
+   \return
+        - -1 on error
+        - number of opened files
+*/
+int get_opened_fd_count(void);
+
+/**
  * \brief create a unique id for a message (used for pop, stored per message)
  * \param target target string. Length should be UID_SIZE 
  * \param message_idnr message_idnr of message


### PR DESCRIPTION
After network connection to DB server goes down the processing of IMAP session
stalls: DB connection pool becomes exhausted as active connections do not
close till TCP timeout kicks in (true at least for Oracle). While DBMail still
accepts incoming connections it quickly reaches the RLIMIT_NOFILE and becomes
unresponsive. Send BYE response if the number of opened FDs reaches the
RLIMIT_NOFILE value.
