### PR TITLE
Use unique foreign key name as …

### DIFF
--- a/sql/mysql/create_tables.mysql
+++ b/sql/mysql/create_tables.mysql
@@ -404,7 +404,7 @@ CREATE TABLE dbmail_auto_replies (
         stop_date DATETIME NOT NULL,
         reply_body MEDIUMTEXT,
         INDEX user_idnr_index (user_idnr),
-        FOREIGN KEY user_idnr_fk (user_idnr)
+        FOREIGN KEY user_idnr_ar_fk (user_idnr)
                 REFERENCES dbmail_users (user_idnr) ON DELETE CASCADE ON UPDATE CASCADE
 ) ENGINE InnoDB DEFAULT CHARSET=utf8;
                              


### PR DESCRIPTION
- user_idnr_fk is already used on dbmail_auto_notifications table

Otherwise it gives the following error during installation:

````ERROR 1005 (HY000) at line 401: Can't create table `dbmail`.`dbmail_auto_replies` (errno: 121 "Duplicate key on write or update")````

