### PR TITLE
fix detection of systemd libs on systemd >= 230

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -350,9 +350,9 @@ AC_DEFUN([DM_CHECK_SSL], [
 
 AC_DEFUN([DM_CHECK_SYSTEMD], [
 	PKG_CHECK_MODULES([SYSTEMD], [libsystemd-daemon], , [
-		PKG_CHECK_MODULES([SYSTEMD], [systemd >= 230])
+		PKG_CHECK_MODULES([SYSTEMD], [libsystemd >= 230])
 	])
-	if test [ -n $SYSTEMD_LIBS ]; then
+	if test [ -n "$SYSTEMD_LIBS" ]; then
 		AC_DEFINE([HAVE_SYSTEMD], [1], [Define if systemd will be used])
 		LDFLAGS="$LDFLAGS $SYSTEMD_LIBS"
 	fi


### PR DESCRIPTION
There was a mistake in https://github.com/pjstevns/dbmail/commit/c6773f6b5ff6d87513c3759565df1700128c7e42 that I missed.

I have tested this change with systemd-226 and systemd-231