### PR TITLE
mysql 5.7 prepared insert hang workaround (#49)

### DIFF
--- a/src/clientbase.c
+++ b/src/clientbase.c
@@ -515,9 +515,13 @@ void ci_authlog_init(ClientBase_T *client, const char *service, const char *user
 		db_stmt_set_int(s, 6, atoi(client->dst_port));
 		db_stmt_set_str(s, 7, status);
 
-		r = db_stmt_query(s);
-		
-		if(strcmp(AUTHLOG_ERR,status)!=0) client->authlog_id = db_insert_result(c, r);
+		if (db_params.db_driver == DM_DRIVER_ORACLE || db_params.db_driver == DM_DRIVER_MYSQL) {
+			db_stmt_exec(s);
+			if(strcmp(AUTHLOG_ERR,status)!=0) client->authlog_id = db_get_pk(c, "authlog");
+		} else {
+			r = db_stmt_query(s);
+			if(strcmp(AUTHLOG_ERR,status)!=0) client->authlog_id = db_insert_result(c, r);
+		}
 	CATCH(SQLException)
 		LOG_SQLERROR;
 	FINALLY

--- a/src/dm_message.c
+++ b/src/dm_message.c
@@ -191,7 +191,7 @@ static uint64_t blob_insert(const char *buf, const char *hash)
 		db_stmt_set_str(s, 1, hash);
 		db_stmt_set_blob(s, 2, buf, l);
 		db_stmt_set_int(s, 3, l);
-		if (db_params.db_driver == DM_DRIVER_ORACLE) {
+		if (db_params.db_driver == DM_DRIVER_ORACLE || db_params.db_driver == DM_DRIVER_MYSQL) {
 			db_stmt_exec(s);
 			id = db_get_pk(c, "mimeparts");
 		} else {
@@ -1451,7 +1451,7 @@ static int _header_name_get_id(const DbmailMessage *self, const char *header, ui
 
 			db_stmt_set_str(s,1,safe_header);
 
-			if (db_params.db_driver == DM_DRIVER_ORACLE) {
+			if (db_params.db_driver == DM_DRIVER_ORACLE || db_params.db_driver == DM_DRIVER_MYSQL) {
 				db_stmt_exec(s);
 				*tmp = db_get_pk(c, "headername");
 			} else {
@@ -1534,7 +1534,7 @@ static uint64_t _header_value_insert(Connection_T c, const char *value, const ch
 	if (datesize)
 		db_stmt_set_str(s, 4, datefield);
 
-	if (db_params.db_driver == DM_DRIVER_ORACLE) {
+	if (db_params.db_driver == DM_DRIVER_ORACLE || db_params.db_driver == DM_DRIVER_MYSQL) {
 		db_stmt_exec(s);
 		id = db_get_pk(c, "headervalue");
 	} else {


### PR DESCRIPTION
The issue is related to mysql bug 85105 and libzdb issue 21.

Basically, libzdb's MysqlPreparedStatement_executeQuery() is setting the cursor type to read-only, which mysql 5.7 does not particularly enjoy when combined with INSERT statements. As a result, every call to dbmail's db_stmt_query() leads to a hang if the prepared statement is an INSERT one.

libzdb's MysqlPreparedStatement_execute() is not affected and hence dbmail's db_stmt_exec() can be used as a workaround, followed up with "SELECT LAST_INSERT_ID()".